### PR TITLE
Register remote .env file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "acto"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a026259da4f1a13b4af60cda453c392de64c58c12d239c560923e0382f42f2b9"
+dependencies = [
+ "parking_lot",
+ "pin-project-lite",
+ "rustc_version",
+ "smol_str",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,6 +1933,7 @@ dependencies = [
  "strum",
  "stun-rs",
  "surge-ping",
+ "swarm-discovery",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -3943,6 +3958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+
+[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4126,6 +4147,21 @@ dependencies = [
  "rand 0.9.2",
  "socket2 0.6.2",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "swarm-discovery"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a95032b94c1dc318f55e0b130e3d2176cda022310a65c3df0092764ea69562"
+dependencies = [
+ "acto",
+ "anyhow",
+ "hickory-proto",
+ "rand 0.8.5",
+ "socket2 0.5.10",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,13 +26,14 @@ rand = "0.8"
 zeroize = "1.7"
 secrecy = "0.10.3"
 iroh-blobs = "0.35"
-iroh = "0.35"
+iroh = { version = "0.35", features = ["discovery-local-network"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1.89"
 futures = "0.3.31"
 iroh-io = "0.6.2"
+tempfile = "3.24.0"
 
 [dev-dependencies]
 assert_cmd = "2.1.2"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -95,13 +95,22 @@ pub async fn register(
         RegisterSource::Remote { ticket, filename } => {
             // Remote registration: download from P2P
             use crate::network::{IrohNetwork, Network};
+            use iroh_blobs::store::fs::Store as FsStore;
+            use tempfile::TempDir;
 
             let filename = filename.unwrap_or_else(|| ".env".to_string());
 
             info!("Connecting to peer and downloading environment...");
 
-            // Initialize network and download the blob
-            let network = IrohNetwork::spawn(store.get_store_clone()).await?;
+            // Create a temporary store for the download operation
+            // This avoids conflicts with the main store when shutting down the network
+            let temp_dir = TempDir::new().context("Failed to create temp directory")?;
+            let temp_store = FsStore::load(temp_dir.path())
+                .await
+                .context("Failed to create temporary store")?;
+
+            // Initialize network with temporary store and download the blob
+            let network = IrohNetwork::spawn(temp_store).await?;
             let result = network.connect_and_download(&ticket).await;
 
             // Cleanup network regardless of result
@@ -113,7 +122,11 @@ pub async fn register(
             info!("Downloaded blob with hash: {}", hash);
 
             // Then return shutdown error if it exists
-            shutdown_result?;
+            if let Err(e) = shutdown_result {
+                warn!("Network shutdown error (non-fatal): {:#}", e);
+            }
+
+            // temp_dir will be automatically cleaned up when dropped
 
             (filename, encrypted_bytes)
         }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -102,12 +102,18 @@ pub async fn register(
 
             // Initialize network and download the blob
             let network = IrohNetwork::spawn(store.get_store_clone()).await?;
-            let (hash, encrypted_bytes) = network.connect_and_download(&ticket).await?;
+            let result = network.connect_and_download(&ticket).await;
+
+            // Cleanup network regardless of result
+            let shutdown_result = Box::new(network).shutdown().await;
+
+            // Return download error first if it exists
+            let (hash, encrypted_bytes) = result?;
 
             info!("Downloaded blob with hash: {}", hash);
 
-            // Cleanup network
-            Box::new(network).shutdown().await?;
+            // Then return shutdown error if it exists
+            shutdown_result?;
 
             (filename, encrypted_bytes)
         }
@@ -305,7 +311,10 @@ pub async fn share(args: ShareArgs<'_>, store: &crate::store::iroh::IrohStore) -
 
     info!("Sharing environment: {}/{}", args.project, args.env);
     println!("\nTo clone this environment, run:");
-    println!("  envbro clone {}\n", ticket);
+    println!(
+        "  envbro register {} {} --ticket {}\n",
+        args.project, args.env, ticket
+    );
     println!("Press Ctrl+C to stop sharing...");
 
     // Wait for Ctrl+C

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -10,69 +10,169 @@ use std::fs;
 use std::path::Path;
 use tracing::{info, warn};
 
+pub enum RegisterSource {
+    Local {
+        path: String,
+    },
+    Remote {
+        ticket: String,
+        filename: Option<String>,
+    },
+}
+
+pub struct RegisterArgs<'a> {
+    pub project: &'a str,
+    pub env: &'a str,
+    pub force: bool,
+    pub passphrase: Option<&'a SecretString>,
+}
+
+pub struct SetArgs<'a> {
+    pub project: &'a str,
+    pub env: &'a str,
+    pub force: bool,
+    pub passphrase: &'a SecretString,
+}
+
+pub struct RmArgs<'a> {
+    pub project: &'a str,
+    pub env: &'a str,
+    pub force: bool,
+    pub passphrase: &'a SecretString,
+}
+
+pub struct ListArgs<'a> {
+    pub project: Option<&'a str>,
+}
+
+pub struct ShowArgs<'a> {
+    pub project: &'a str,
+    pub env: &'a str,
+    pub passphrase: &'a SecretString,
+}
+
+pub struct ShareArgs<'a> {
+    pub project: &'a str,
+    pub env: &'a str,
+}
+
 pub async fn register(
-    project: &str,
-    env: &str,
-    target_path: &str,
-    force: bool,
-    passphrase: &SecretString,
-    store: &impl Store,
+    args: RegisterArgs<'_>,
+    source: RegisterSource,
+    store: &crate::store::iroh::IrohStore,
 ) -> Result<()> {
-    if env.contains('/') {
+    if args.env.contains('/') {
         bail!("Environment name cannot contain /");
     }
 
-    let target_path = Path::new(target_path);
-    if !target_path.exists() || !target_path.is_file() {
-        bail!("Target file doesn't exist or is not a file");
-    }
+    // Determine the filename and content source
+    let (target_filename, encrypted_content_bytes) = match source {
+        RegisterSource::Local { path } => {
+            // Local registration: read from file
+            let passphrase = args
+                .passphrase
+                .context("Passphrase required for local registration")?;
 
-    // Check existing
-    if let Ok((_, encrypted_content)) = store.get(project, env).await {
-        let old_content_bytes = security::decrypt(&encrypted_content, passphrase)
-            .context("Failed to decrypt existing env file")?;
-        let old_content =
-            String::from_utf8(old_content_bytes).context("Stored content is not valid UTF-8")?;
-        let new_content = fs::read_to_string(target_path).context("Failed to read target file")?;
+            let target_path = Path::new(&path);
+            if !target_path.exists() || !target_path.is_file() {
+                bail!("Target file doesn't exist or is not a file");
+            }
 
-        if old_content != new_content {
-            println!("What you have stored now vs What will be stored if you continue:");
-            print_diff(&old_content, &new_content);
+            let new_content_bytes = fs::read(target_path).context("Failed to read target file")?;
+            // Verify it is UTF-8
+            let _ = std::str::from_utf8(&new_content_bytes)
+                .context("Target file is not valid UTF-8")?;
 
-            if !force
-                && !Confirm::with_theme(&ColorfulTheme::default())
-                    .with_prompt("Are you sure you want to change the stored env?")
-                    .interact()?
+            let filename = target_path
+                .file_name()
+                .context("Invalid target filename")?
+                .to_string_lossy()
+                .to_string();
+
+            let encrypted = security::encrypt(&new_content_bytes, passphrase)?;
+            (filename, encrypted)
+        }
+        RegisterSource::Remote { ticket, filename } => {
+            // Remote registration: download from P2P
+            use crate::network::{IrohNetwork, Network};
+
+            let filename = filename.unwrap_or_else(|| ".env".to_string());
+
+            info!("Connecting to peer and downloading environment...");
+
+            // Initialize network and download the blob
+            let network = IrohNetwork::spawn(store.get_store_clone()).await?;
+            let (hash, encrypted_bytes) = network.connect_and_download(&ticket).await?;
+
+            info!("Downloaded blob with hash: {}", hash);
+
+            // Cleanup network
+            Box::new(network).shutdown().await?;
+
+            (filename, encrypted_bytes)
+        }
+    };
+
+    // Check existing and show diff if applicable
+    if let Ok((_, existing_encrypted)) = store.get(args.project, args.env).await {
+        if args.passphrase.is_some() {
+            // Only show diff if we have a passphrase to decrypt
+            let old_content_bytes =
+                security::decrypt(&existing_encrypted, args.passphrase.unwrap())
+                    .context("Failed to decrypt existing env file")?;
+            let old_content = String::from_utf8(old_content_bytes)
+                .context("Stored content is not valid UTF-8")?;
+
+            let new_content_bytes =
+                security::decrypt(&encrypted_content_bytes, args.passphrase.unwrap())
+                    .context("Failed to decrypt new content")?;
+            let new_content =
+                String::from_utf8(new_content_bytes).context("New content is not valid UTF-8")?;
+
+            if old_content != new_content {
+                println!("What you have stored now vs What will be stored if you continue:");
+                print_diff(&old_content, &new_content);
+
+                if !args.force
+                    && !Confirm::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Are you sure you want to change the stored env?")
+                        .interact()?
+                {
+                    return Ok(());
+                }
+            }
+        } else if !args.force {
+            // Remote registration without passphrase: just ask for overwrite confirmation
+            if !Confirm::with_theme(&ColorfulTheme::default())
+                .with_prompt(format!(
+                    "Environment {}/{} already exists. Overwrite?",
+                    args.project, args.env
+                ))
+                .interact()?
             {
                 return Ok(());
             }
         }
     }
 
-    let new_content_bytes = fs::read(target_path).context("Failed to read target file")?;
-    // Verify it is UTF-8
-    let _ = std::str::from_utf8(&new_content_bytes).context("Target file is not valid UTF-8")?;
-
-    let filename = target_path
-        .file_name()
-        .context("Invalid target filename")?
-        .to_string_lossy();
-
-    let encrypted = security::encrypt(&new_content_bytes, passphrase)?;
-    store.put(project, env, &filename, &encrypted).await?;
-    info!("New env stored");
+    store
+        .put(
+            args.project,
+            args.env,
+            &target_filename,
+            &encrypted_content_bytes,
+        )
+        .await?;
+    info!(
+        "Environment {}/{} registered successfully",
+        args.project, args.env
+    );
 
     Ok(())
 }
 
-pub async fn set_env(
-    project: &str,
-    env: &str,
-    force: bool,
-    passphrase: &SecretString,
-    store: &impl Store,
-) -> Result<()> {
-    let (target_file_name, encrypted_stored) = match store.get(project, env).await {
+pub async fn set_env(args: SetArgs<'_>, store: &impl Store) -> Result<()> {
+    let (target_file_name, encrypted_stored) = match store.get(args.project, args.env).await {
         Ok(data) => data,
         Err(_) => {
             warn!("Env not found");
@@ -82,7 +182,7 @@ pub async fn set_env(
 
     let target_file_path = std::env::current_dir()?.join(&target_file_name);
 
-    let decrypted_content_bytes = security::decrypt(&encrypted_stored, passphrase)
+    let decrypted_content_bytes = security::decrypt(&encrypted_stored, args.passphrase)
         .context("Failed to decrypt stored env file")?;
 
     let new_content =
@@ -96,7 +196,7 @@ pub async fn set_env(
             println!("What you have now vs What you will have if you continue:");
             print_diff(&old_content, &new_content);
 
-            if !force
+            if !args.force
                 && !Confirm::with_theme(&ColorfulTheme::default())
                     .with_prompt("Are you sure you want to change the env you have right now?")
                     .interact()?
@@ -108,25 +208,19 @@ pub async fn set_env(
 
     fs::write(&target_file_path, new_content.as_bytes())
         .context("Failed to write target env file")?;
-    info!("{} set to {}", env, target_file_name);
+    info!("{} set to {}", args.env, target_file_name);
 
     Ok(())
 }
 
-pub async fn remove(
-    project: &str,
-    env: &str,
-    force: bool,
-    passphrase: &SecretString,
-    store: &impl Store,
-) -> Result<()> {
+pub async fn remove(args: RmArgs<'_>, store: &impl Store) -> Result<()> {
     // Check if exists
-    if let Ok((_, encrypted_content)) = store.get(project, env).await {
-        let content_bytes = security::decrypt(&encrypted_content, passphrase)
+    if let Ok((_, encrypted_content)) = store.get(args.project, args.env).await {
+        let content_bytes = security::decrypt(&encrypted_content, args.passphrase)
             .context("Failed to decrypt env file for confirmation")?;
         let content = String::from_utf8_lossy(&content_bytes);
 
-        if !force {
+        if !args.force {
             if !Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt(format!(
                     "Are you sure you want to remove this?:\n\n{}",
@@ -145,8 +239,8 @@ pub async fn remove(
             }
         }
 
-        store.delete(project, env).await?;
-        info!("Removed env: {}", env);
+        store.delete(args.project, args.env).await?;
+        info!("Removed env: {}", args.env);
     } else {
         warn!("Env does not exist");
     }
@@ -154,8 +248,8 @@ pub async fn remove(
     Ok(())
 }
 
-pub async fn list(project: Option<&str>, store: &impl Store) -> Result<()> {
-    if let Some(p) = project {
+pub async fn list(args: ListArgs<'_>, store: &impl Store) -> Result<()> {
+    if let Some(p) = args.project {
         println!("{}", p);
         let envs = store.list_envs(p).await?;
         if envs.is_empty() {
@@ -182,15 +276,10 @@ pub async fn list(project: Option<&str>, store: &impl Store) -> Result<()> {
     Ok(())
 }
 
-pub async fn show(
-    project: &str,
-    env: &str,
-    passphrase: &SecretString,
-    store: &impl Store,
-) -> Result<()> {
-    match store.get(project, env).await {
+pub async fn show(args: ShowArgs<'_>, store: &impl Store) -> Result<()> {
+    match store.get(args.project, args.env).await {
         Ok((_, encrypted_content)) => {
-            let content_bytes = security::decrypt(&encrypted_content, passphrase)?;
+            let content_bytes = security::decrypt(&encrypted_content, args.passphrase)?;
             let content = String::from_utf8_lossy(&content_bytes);
             println!("{}", content);
         }
@@ -202,11 +291,11 @@ pub async fn show(
     Ok(())
 }
 
-pub async fn share(project: &str, env: &str, store: &crate::store::iroh::IrohStore) -> Result<()> {
+pub async fn share(args: ShareArgs<'_>, store: &crate::store::iroh::IrohStore) -> Result<()> {
     use crate::network::IrohNetwork;
 
     // Get the hash for this environment
-    let hash = store.get_hash(project, env).await?;
+    let hash = store.get_hash(args.project, args.env).await?;
 
     // Create network node with shared store
     let network = IrohNetwork::spawn(store.get_store_clone()).await?;
@@ -214,7 +303,7 @@ pub async fn share(project: &str, env: &str, store: &crate::store::iroh::IrohSto
     // Generate ticket
     let ticket = network.share(hash).await?;
 
-    info!("Sharing environment: {}/{}", project, env);
+    info!("Sharing environment: {}/{}", args.project, args.env);
     println!("\nTo clone this environment, run:");
     println!("  envbro clone {}\n", ticket);
     println!("Press Ctrl+C to stop sharing...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,9 +34,15 @@ enum Commands {
         project: String,
         /// Environment name
         env: String,
-        /// Path to the environment file
+        /// Path to a local environment file
+        #[arg(long, conflicts_with = "ticket")]
+        path: Option<String>,
+        /// Iroh ticket for remote environment
+        #[arg(long, conflicts_with = "path")]
+        ticket: Option<String>,
+        /// Target filename (used with --ticket, default: .env)
         #[arg(long)]
-        path: String,
+        filename: Option<String>,
         /// Skip confirmation prompts
         #[arg(short, long)]
         force: bool,
@@ -90,6 +96,9 @@ async fn main() -> Result<()> {
 
     let passphrase_input = match &cli.command {
         Commands::List { .. } | Commands::Share { .. } => None, // Not needed for listing or sharing
+        Commands::Register {
+            ticket: Some(_), ..
+        } => None, // Not needed for remote registration (blob already encrypted)
         _ => {
             if let Ok(p) = std::env::var("ENVBRO_PASSPHRASE") {
                 Some(SecretString::from(p))
@@ -112,10 +121,12 @@ async fn main() -> Result<()> {
             force,
         } => {
             commands::set_env(
-                &project,
-                &env,
-                force,
-                passphrase.expect("Passphrase required for set"),
+                commands::SetArgs {
+                    project: &project,
+                    env: &env,
+                    force,
+                    passphrase: passphrase.expect("Passphrase required for set"),
+                },
                 &store,
             )
             .await?
@@ -124,17 +135,29 @@ async fn main() -> Result<()> {
             project,
             env,
             path,
+            ticket,
+            filename,
             force,
         } => {
-            commands::register(
-                &project,
-                &env,
-                &path,
+            let source = if let Some(p) = path {
+                commands::RegisterSource::Local { path: p }
+            } else if let Some(t) = ticket {
+                commands::RegisterSource::Remote {
+                    ticket: t,
+                    filename,
+                }
+            } else {
+                anyhow::bail!("Must provide either --path or --ticket");
+            };
+
+            let args = commands::RegisterArgs {
+                project: &project,
+                env: &env,
                 force,
-                passphrase.expect("Passphrase required for register"),
-                &store,
-            )
-            .await?
+                passphrase,
+            };
+
+            commands::register(args, source, &store).await?
         }
         Commands::Rm {
             project,
@@ -142,25 +165,46 @@ async fn main() -> Result<()> {
             force,
         } => {
             commands::remove(
-                &project,
-                &env,
-                force,
-                passphrase.expect("Passphrase required for rm"),
+                commands::RmArgs {
+                    project: &project,
+                    env: &env,
+                    force,
+                    passphrase: passphrase.expect("Passphrase required for rm"),
+                },
                 &store,
             )
             .await?
         }
-        Commands::List { project } => commands::list(project.as_deref(), &store).await?,
+        Commands::List { project } => {
+            commands::list(
+                commands::ListArgs {
+                    project: project.as_deref(),
+                },
+                &store,
+            )
+            .await?
+        }
         Commands::Show { project, env } => {
             commands::show(
-                &project,
-                &env,
-                passphrase.expect("Passphrase required for show"),
+                commands::ShowArgs {
+                    project: &project,
+                    env: &env,
+                    passphrase: passphrase.expect("Passphrase required for show"),
+                },
                 &store,
             )
             .await?
         }
-        Commands::Share { project, env } => commands::share(&project, &env, &store).await?,
+        Commands::Share { project, env } => {
+            commands::share(
+                commands::ShareArgs {
+                    project: &project,
+                    env: &env,
+                },
+                &store,
+            )
+            .await?
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ enum Commands {
         #[arg(long, conflicts_with = "path")]
         ticket: Option<String>,
         /// Target filename (used with --ticket, default: .env)
-        #[arg(long)]
+        #[arg(long, requires = "ticket", conflicts_with = "path")]
         filename: Option<String>,
         /// Skip confirmation prompts
         #[arg(short, long)]

--- a/src/network/iroh.rs
+++ b/src/network/iroh.rs
@@ -8,7 +8,7 @@ use iroh::Endpoint;
 use iroh_blobs::downloader::DownloadRequest;
 use iroh_blobs::net_protocol::Blobs;
 use iroh_blobs::store::fs::Store as FsStore;
-use iroh_blobs::store::{Map, MapEntry, Store};
+use iroh_blobs::store::{Map, MapEntry};
 use iroh_blobs::ticket::BlobTicket;
 use iroh_blobs::{BlobFormat, Hash, HashAndFormat};
 use iroh_io::AsyncSliceReader;
@@ -22,24 +22,18 @@ pub struct IrohNetwork {
 impl IrohNetwork {
     /// Create and spawn a new Iroh node with the given blob store.
     pub async fn spawn(store: FsStore) -> Result<Self> {
-        // TODO: add possibility of using owner's infra
-        let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+        // Enable both n0 discovery (for internet) and local network discovery (for local testing)
+        let endpoint = Endpoint::builder()
+            .discovery_n0()
+            .discovery_local_network()
+            .bind()
+            .await?;
         let blobs = Blobs::builder(store).build(&endpoint);
         let router = Router::builder(endpoint)
             .accept(iroh_blobs::ALPN, blobs.clone())
             .spawn();
 
         Ok(Self { router, blobs })
-    }
-
-    /// Get a reference to the blobs protocol handler.
-    pub fn blobs(&self) -> &Blobs<FsStore> {
-        &self.blobs
-    }
-
-    /// Get a reference to the underlying store.
-    pub fn store(&self) -> &FsStore {
-        self.blobs.store()
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -22,7 +22,7 @@ fn test_register_and_list() {
         .arg(src_env.to_str().unwrap())
         .assert()
         .success()
-        .stderr(predicate::str::contains("New env stored"));
+        .stderr(predicate::str::contains("registered successfully"));
 
     // Verify it exists in the store via list
     let mut cmd_list = Command::new(env!("CARGO_BIN_EXE_envbro"));

--- a/tests/p2p_sync.rs
+++ b/tests/p2p_sync.rs
@@ -30,6 +30,10 @@ async fn test_p2p_blob_transfer() -> Result<()> {
 
     // Spawn provider node
     let provider = IrohNetwork::spawn(provider_store).await?;
+
+    // Allow some time for the provider to discover local addresses
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
     let ticket_str = provider.share(hash).await?;
 
     println!("Provider sharing ticket: {}", ticket_str);


### PR DESCRIPTION
This pull request refactors the command argument handling in `src/commands.rs` and `src/main.rs` to use dedicated argument structs for each command, improving code clarity, maintainability, and extensibility. It also enhances the `register` command to support both local file and remote ticket-based registration, and improves user prompts and output messages for a more user-friendly experience.

**Refactoring and improved argument handling:**

* Introduced argument structs (`RegisterArgs`, `SetArgs`, `RmArgs`, `ListArgs`, `ShowArgs`, `ShareArgs`) for all command functions in `src/commands.rs`, replacing positional parameters for better clarity and extensibility. Updated all command functions and their invocations to use these structs.

**Feature enhancements:**

* Enhanced the `register` command to support both local file registration (`--path`) and remote registration using a P2P ticket (`--ticket`). Added a `RegisterSource` enum to distinguish between these modes and updated command-line parsing accordingly.

**User experience improvements:**

* Improved confirmation prompts and diff displays in the `register`, `set_env`, and `remove` commands to be more context-aware and user-friendly, including conditional handling for remote registrations and missing passphrases.
* Updated output messages for successful operations to be more descriptive and consistent (e.g., "registered successfully" instead of "New env stored"). 

**Testing:**

* Adjusted CLI test assertions to match the new output messages for successful registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register now supports remote registration via ticket + optional filename in addition to local file path.
  * Registration enforces either path or ticket be supplied.

* **Bug Fixes / UX**
  * Improved overwrite/diff prompts and passphrase handling when registering, setting, showing, removing, or sharing envs.
  * Success message updated to "registered successfully".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->